### PR TITLE
Add full-volume data loader for 3D training

### DIFF
--- a/3D unet.py
+++ b/3D unet.py
@@ -14,7 +14,7 @@ from keras.callbacks import ModelCheckpoint, CSVLogger
 from keras import backend as K
 from keras.regularizers import l2
 from keras.utils import plot_model
-from data3D import get_filenames, create_patch_dataset
+from data3D import get_filenames, create_patch_dataset, load_full_dataset
 
 
 
@@ -86,7 +86,7 @@ def train():
     print('-'*30)
     
     train_dirs, mask_dirs = get_filenames()
-    train_arrays_list, mask_arrays_list, patient_list = create_patch_dataset()
+    volumes, masks = load_full_dataset(target_shape=(img_depth, img_rows, img_cols))
 
     print('-'*30)
     print('Creating and compiling model...')
@@ -108,15 +108,13 @@ def train():
     print('Fitting model...')
     print('-'*30)
  
-    # for list of arrays as input
-    # model.train_on_batch(train_arrays_list, mask_arrays_list)
-    #remove fit()
-    model.fit(np.array(train_arrays_list), np.array(mask_arrays_list), 
-              batch_size=1, 
-              epochs=50, 
-              verbose=1, 
-              shuffle=True, 
-              validation_split=0.10, 
+    # Train directly on full volumes
+    model.fit(volumes, masks,
+              batch_size=1,
+              epochs=50,
+              verbose=1,
+              shuffle=True,
+              validation_split=0.10,
               callbacks=[model_checkpoint, csv_logger])
 
 
@@ -124,4 +122,3 @@ def train():
     print('-'*30)
     print('Training finished')
     print('-'*30)
-    

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ I uploaded the .py files and a Google Colab notebook where I trained the 3d-Unet
 Files:
 
 1. Data3D.py: Data Preprocessing
+   - `load_full_dataset`: load entire 3D volumes and masks resized to a common
+     shape for training without patch extraction.
 
 2. 3D UNet.py: model design, training, testing and evaluation.
 
@@ -37,7 +39,4 @@ Patches of size 128x128x128:
 7. Loss and Loss Validation Plots
 8. Comparing predicted segmantation with scans and masks
 9. Future work for improving results
-
-
-
 Keras/TensorFlow API

--- a/data3D.py
+++ b/data3D.py
@@ -79,8 +79,50 @@ def create_patch_dataset():
     
     print('Loading of train and mask datasets done.')
     print('Saving to .npy files done.')
-    
+
     return train_arrays_list, mask_arrays_list, patient_list_img, patient_list_mask
+
+
+# New helper to load entire 3D volumes without patch extraction
+def load_full_dataset(target_shape=(128, 128, 128)):
+    """Load all training volumes and masks resized to a common shape.
+
+    Parameters
+    ----------
+    target_shape : tuple of int, optional
+        Desired output shape in (depth, height, width). All volumes and masks
+        will be resized to this shape for training.
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        Arrays containing volumes and masks with shape
+        (n_samples, depth, height, width, 1).
+    """
+
+    train_files, mask_files = get_filenames()
+    train_data_path = os.path.join(data_path, 'volume/')
+    mask_data_path = os.path.join(data_path, 'mask/')
+
+    volumes = []
+    masks = []
+    for scan_fname, mask_fname in zip(train_files, mask_files):
+        img_train = sitk.ReadImage(os.path.join(train_data_path, scan_fname))
+        vol = sitk.GetArrayFromImage(img_train)
+        img_mask = sitk.ReadImage(os.path.join(mask_data_path, mask_fname))
+        mask = sitk.GetArrayFromImage(img_mask)
+
+        if vol.shape != target_shape:
+            vol = resize(vol, target_shape, mode='constant', preserve_range=True)
+        if mask.shape != target_shape:
+            mask = resize(mask, target_shape, mode='constant', preserve_range=True, order=0)
+
+        vol = vol.astype('float32') / 255.
+        mask = mask.astype('float32') / 255.
+        volumes.append(np.expand_dims(vol, axis=3))
+        masks.append(np.expand_dims(mask, axis=3))
+
+    return np.array(volumes), np.array(masks)
 
 
 


### PR DESCRIPTION
## Summary
- extend `data3D.py` with `load_full_dataset` to read complete 3D volumes
- modify training code in `3D unet.py` to use the new loader
- document new loader in README

## Testing
- `python -m py_compile data3D.py '3D unet.py'`

------
https://chatgpt.com/codex/tasks/task_e_683fa31e9a7c83309748680ef88cc1a1